### PR TITLE
fix eslint warnings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,6 @@
 webpack*
+.eslintrc.js
+next.config.js
+tailwind.config.js
+postcss.config.js
+convex/_generated/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,23 @@
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+  plugins: ['@typescript-eslint'],
   extends: [
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    'plugin:@typescript-eslint/recommended-type-checked',
     'plugin:@next/next/recommended',
   ],
   parserOptions: {
+    project: './tsconfig.json',
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module', // Allows for the use of imports
   },
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-unused-vars': ["warn", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { varsIgnorePattern: '^_', argsIgnorePattern: '^_' },
+    ],
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@next/next/no-img-element': 'off',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    'plugin:@next/next/recommended',
   ],
   parserOptions: {
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
@@ -10,5 +11,8 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-unused-vars': ["warn", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@next/next/no-img-element': 'off',
   },
 };

--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -93,7 +93,7 @@ function divideIntoGroups(players: Player[]) {
   const groups: Player[][] = [];
   const solos: Player[] = [];
   while (playerById.size > 0) {
-    const player = playerById.values().next().value;
+    const player = playerById.values().next().value as Player;
     playerById.delete(player.id);
     const nearbyPlayers = getNearbyPlayers(player.motion, [...playerById.values()]);
     if (nearbyPlayers.length > 0) {
@@ -293,7 +293,7 @@ function handleDone(ctx: ActionCtx, noSchedule?: boolean): DoneFn {
   // Simple serialization: only one agent finishes at a time.
   const queue = new Set<Promise<unknown>>();
   return async (agentId, activity) => {
-    let unlock;
+    let unlock: (v: unknown) => void = () => {};
     const wait = new Promise((resolve) => (unlock = resolve));
     const toAwait = [...queue];
     queue.add(wait);
@@ -301,7 +301,7 @@ function handleDone(ctx: ActionCtx, noSchedule?: boolean): DoneFn {
       await Promise.allSettled(toAwait);
       await doIt(agentId, activity);
     } finally {
-      unlock!();
+      unlock(null);
       queue.delete(wait);
     }
   };

--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -63,7 +63,7 @@ export const runAgentBatch = internalAction({
         }
       } catch (e) {
         console.error('agent failed, going for a walk: ', player.agentId);
-        await done(player.agentId!, { type: 'walk', ignore: [] });
+        await done(player.agentId, { type: 'walk', ignore: [] });
         throw e;
       }
     });
@@ -291,7 +291,7 @@ function handleDone(ctx: ActionCtx, noSchedule?: boolean): DoneFn {
     });
   };
   // Simple serialization: only one agent finishes at a time.
-  let queue = new Set<Promise<unknown>>();
+  const queue = new Set<Promise<unknown>>();
   return async (agentId, activity) => {
     let unlock;
     const wait = new Promise((resolve) => (unlock = resolve));

--- a/convex/characterdata/data.ts
+++ b/convex/characterdata/data.ts
@@ -1,4 +1,3 @@
-import { data as playerSpritesheetData } from './spritesheets/player';
 import { data as f1SpritesheetData } from './spritesheets/f1';
 import { data as f2SpritesheetData } from './spritesheets/f2';
 import { data as f3SpritesheetData } from './spritesheets/f3';

--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -76,7 +76,7 @@ function conversationQuery(db: DatabaseReader, conversationId: Id<'conversations
   return (
     db
       .query('journal')
-      .withIndex('by_conversation', (q) => q.eq('data.conversationId', conversationId as any))
+      .withIndex('by_conversation', (q) => q.eq('data.conversationId', conversationId as any as undefined))
       // .filter((q) => q.eq(q.field('data.type'), 'talking'))
       .order('desc')
   );

--- a/convex/conversation.ts
+++ b/convex/conversation.ts
@@ -15,10 +15,11 @@ export async function startConversation(
   player: Player,
 ) {
   const newFriendsNames = audience.map((p) => p.name);
+  const newFriendsNamesStr = newFriendsNames.join(',');
 
   const { embedding } = await fetchEmbeddingWithCache(
     ctx,
-    `What do you think about ${newFriendsNames.join(',')}?`,
+    `What do you think about ${newFriendsNamesStr}?`,
     { write: true },
   );
   const memories = await memory.accessMemories(player.id, embedding);
@@ -29,7 +30,7 @@ export async function startConversation(
     {
       role: 'user',
       content:
-        `You are ${player.name}. You just saw ${newFriendsNames}. You should greet them and start a conversation with them. Below are some of your memories about ${newFriendsNames}:` +
+        `You are ${player.name}. You just saw ${newFriendsNamesStr}. You should greet them and start a conversation with them. Below are some of your memories about ${newFriendsNamesStr}:` +
         audience
           .filter((r) => r.relationship)
           .map((r) => `Relationship with ${r.name}: ${r.relationship}`)
@@ -111,9 +112,10 @@ export async function decideWhoSpeaksNext(
     },
   ];
   const { content } = await chatCompletion({ messages: prompt, max_tokens: 300 });
-  let speakerId: string;
+  let speakerId: string | undefined = undefined;
   try {
-    speakerId = JSON.parse(content).id;
+    const contentJSON = JSON.parse(content) as {id: string};
+    speakerId = contentJSON.id;
   } catch (e) {
     console.error('error parsing speakerId: ', e);
   }

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -13,7 +13,7 @@ import { TableNames } from './_generated/dataModel';
 
 export const recoverThinkingAgents = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const world = await ctx.db.query('worlds').order('desc').first();
     if (!world) throw new Error('No world found');
     // Future: we can check all players, but for now just the most recent world.
@@ -42,7 +42,7 @@ export const recoverThinkingAgents = internalMutation({
 const BUFFER = 1_000;
 export const recoverStoppedAgents = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const world = await ctx.db.query('worlds').order('desc').first();
     if (!world) throw new Error('No world found');
     if (world.frozen) {

--- a/convex/engine.ts
+++ b/convex/engine.ts
@@ -46,7 +46,7 @@ export const tick = internalMutation({
       console.debug("Didn't tick: spurious, no agents eager to wake up");
       return;
     }
-    const agentsToWake = pruneNull(await asyncMap(agentIdsToWake, ctx.db.get)).filter(
+    const agentsToWake = pruneNull(await asyncMap(agentIdsToWake, (id) => ctx.db.get(id))).filter(
       (a) => !a.thinking,
     );
     for (const agentDoc of agentsToWake) {

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -1,5 +1,5 @@
 import { v } from 'convex/values';
-import { internal, api } from './_generated/api';
+import { internal } from './_generated/api';
 import { Doc, Id } from './_generated/dataModel';
 import {
   DatabaseWriter,
@@ -98,7 +98,7 @@ export const addPlayers = internalMutation({
 
 export const reset = internalAction({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     await ctx.runMutation(internal.engine.freezeAll);
     await ctx.runAction(internal.init.seed, { newWorld: true });
   },
@@ -106,7 +106,7 @@ export const reset = internalAction({
 
 export const resetFrozen = internalAction({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     await ctx.runMutation(internal.engine.freezeAll);
     const worldId = await ctx.runAction(internal.init.seed, { newWorld: true, frozen: true });
     console.log('To test one batch a time: npx convex run --no-push engine:tick');
@@ -133,7 +133,7 @@ export const seed = internalAction({
     console.log(`Created world ${worldId}`);
     const memories = Descriptions.flatMap(({ name, memories }) => {
       const playerId = playersByName[name]!;
-      return memories.map((memory, idx) => {
+      return memories.map((memory) => {
         const { description, ...rest } = memory;
         let data: Doc<'memories'>['data'] | undefined;
         if (rest.type === 'relationship') {
@@ -147,7 +147,7 @@ export const seed = internalAction({
         const newMemory = {
           playerId,
           data,
-          description: memory.description,
+          description,
         };
 
         return newMemory;

--- a/convex/journal.ts
+++ b/convex/journal.ts
@@ -32,7 +32,7 @@ import { clientMessageMapper } from './chat';
 export const getSnapshot = internalQuery({
   args: { playerIds: v.array(v.id('players')) },
   handler: async (ctx, args) => {
-    const playerDocs = pruneNull(await asyncMap(args.playerIds, ctx.db.get));
+    const playerDocs = pruneNull(await asyncMap(args.playerIds, (id) => ctx.db.get(id)));
     return {
       players: await asyncMap(playerDocs, (playerDoc) => getPlayer(ctx.db, playerDoc)),
     };

--- a/convex/journal.ts
+++ b/convex/journal.ts
@@ -150,7 +150,7 @@ export async function latestMemoryOfType<T extends MemoryType>(
 
 export const makeConversation = internalMutation({
   args: { playerId: v.id('players'), audience: v.array(v.id('players')) },
-  handler: async (ctx, { playerId, audience, ...args }) => {
+  handler: async (ctx, { playerId, audience }) => {
     const playerDoc = (await ctx.db.get(playerId))!;
     const { worldId } = playerDoc;
     const conversationId = await ctx.db.insert('conversations', { worldId });
@@ -193,7 +193,7 @@ export const leaveConversation = internalMutation({
     audience: v.array(v.id('players')),
     conversationId: v.id('conversations'),
   },
-  handler: async (ctx, { playerId, audience, conversationId, ...args }) => {
+  handler: async (ctx, { playerId, audience, conversationId }) => {
     await ctx.db.insert('journal', {
       playerId,
       data: { type: 'leaveConversation', audience, conversationId },
@@ -318,7 +318,7 @@ export const walk = internalMutation({
 
 export const nextCollision = internalQuery({
   args: { agentId: v.id('agents'), ignore: v.array(v.id('players')) },
-  handler: async (ctx, { agentId, ignore, ...args }) => {
+  handler: async (ctx, { agentId, ignore }) => {
     const ts = Date.now();
     const agentDoc = (await ctx.db.get(agentId))!;
     const { playerId, worldId } = agentDoc;

--- a/convex/lib/memory.ts
+++ b/convex/lib/memory.ts
@@ -195,7 +195,7 @@ export function MemoryDB(ctx: ActionCtx): MemoryDB {
         });
 
         try {
-          const insights: { insight: string; statementIds: number[] }[] = JSON.parse(reflection);
+          const insights = JSON.parse(reflection) as { insight: string; statementIds: number[] }[];
           const memoriesToSave: MemoryOfType<'reflection'>[] = [];
           insights.forEach((item) => {
             const relatedMemoryIds = item.statementIds.map((idx: number) => memories[idx]._id);
@@ -393,7 +393,7 @@ export const getRecentMessages = internalQuery({
     // beginning of time (for this user's conversations).
     const firstMessage = (await ctx.db
       .query('journal')
-      .withIndex('by_conversation', (q) => q.eq('data.conversationId', conversationId as any))
+      .withIndex('by_conversation', (q) => q.eq('data.conversationId', conversationId as any as undefined))
       .first()) as EntryOfType<'talking'>;
 
     // Look for the last conversation memory for this conversation
@@ -413,7 +413,7 @@ export const getRecentMessages = internalQuery({
     const allMessages = (await ctx.db
       .query('journal')
       .withIndex('by_conversation', (q) => {
-        const q2 = q.eq('data.conversationId', conversationId as any);
+        const q2 = q.eq('data.conversationId', conversationId as any as undefined);
         if (lastConversationMemory) {
           // If we have a memory of this conversation, only look at messages after.
           return q2.gt('_creationTime', lastConversationMemory._creationTime);

--- a/convex/lib/memory.ts
+++ b/convex/lib/memory.ts
@@ -16,7 +16,7 @@ import { chatHistoryFromMessages } from '../conversation.js';
 import { MEMORY_ACCESS_THROTTLE } from '../config.js';
 import { fetchEmbeddingBatchWithCache } from './cached_llm.js';
 
-const { embeddingId: _, lastAccess, ...MemoryWithoutEmbeddingId } = Memories.fields;
+const { embeddingId: _, lastAccess: _lastAccess, ...MemoryWithoutEmbeddingId } = Memories.fields;
 const NewMemory = { ...MemoryWithoutEmbeddingId, importance: v.optional(v.number()) };
 const NewMemoryWithEmbedding = { ...MemoryWithoutEmbeddingId, embedding: v.array(v.number()) };
 const NewMemoryObject = v.object(NewMemory);
@@ -196,7 +196,7 @@ export function MemoryDB(ctx: ActionCtx): MemoryDB {
 
         try {
           const insights: { insight: string; statementIds: number[] }[] = JSON.parse(reflection);
-          let memoriesToSave: MemoryOfType<'reflection'>[] = [];
+          const memoriesToSave: MemoryOfType<'reflection'>[] = [];
           insights.forEach((item) => {
             const relatedMemoryIds = item.statementIds.map((idx: number) => memories[idx]._id);
             const reflectionMemory = {

--- a/convex/lib/migrations.ts
+++ b/convex/lib/migrations.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { FunctionReference } from "convex/server";
 import { Doc, TableNames } from "../_generated/dataModel";
 import {
@@ -73,7 +76,7 @@ export const runMigration = internalAction(
         const result: any = await ctx.runMutation(name, args);
         if (result.isDone === undefined) {
           throw new Error(
-            `${name} did not return "isDone" - is it a migration?`
+            `${name as unknown as string} did not return "isDone" - is it a migration?`
           );
         }
         total += result.count;

--- a/convex/lib/openai.ts
+++ b/convex/lib/openai.ts
@@ -34,7 +34,7 @@ export async function chatCompletion(
         error: new Error(`Embedding failed with code ${result.status}: ${await result.text()}`),
       };
     }
-    return (await result!.json()) as CreateChatCompletionResponse;
+    return (await result.json()) as CreateChatCompletionResponse;
   });
   const content = json.choices[0].message?.content;
   if (content === undefined) {
@@ -79,7 +79,7 @@ export async function fetchEmbeddingBatch(texts: string[]) {
         error: new Error(`Embedding failed with code ${result.status}: ${await result.text()}`),
       };
     }
-    return (await result!.json()) as CreateEmbeddingResponse;
+    return (await result.json()) as CreateEmbeddingResponse;
   });
   if (json.data.length !== texts.length) {
     console.error(json);

--- a/convex/lib/pinecone.ts
+++ b/convex/lib/pinecone.ts
@@ -54,7 +54,7 @@ export const deleteVectors = internalAction({
 
 export const deleteAllVectors = internalAction({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (_ctx, _args) => {
     if (pineconeAvailable()) {
       const index = await pineconeIndex();
       const deletionResult = await index._delete({
@@ -72,7 +72,7 @@ export async function upsertVectors<TableName extends TableNames>(
   vectors: { id: Id<TableName>; values: number[]; metadata: object }[],
   index?: VectorOperationsApi,
 ) {
-  const start = Date.now();
+  // const start = Date.now();
   if (!index) {
     index = await pineconeIndex();
   }
@@ -102,7 +102,7 @@ export async function queryVectors<TableName extends TableNames>(
   filter: object,
   limit: number,
 ) {
-  const start = Date.now();
+  // const start = Date.now();
   const pinecone = await pineconeIndex();
   const { matches } = await pinecone.query({
     queryRequest: {

--- a/convex/lib/replicate.ts
+++ b/convex/lib/replicate.ts
@@ -46,7 +46,7 @@ const handlers: {
   [K: string]: (
     prediction: Prediction,
     ctx: ActionCtx,
-  ) => Promise<string & { __tableName: 'music' }>;
+  ) => Promise<Id<'music'>>;
 } = {
   BackgroundMusicGen: backgroundMusicGenHandler,
   //Add more handlers here
@@ -60,7 +60,7 @@ function handleResult(prediction: Prediction, handler: string, ctx: ActionCtx) {
 }
 export const processWebhook = internalAction({
   args: { externalId: v.string() },
-  handler: async (ctx, { externalId, ...args }) => {
+  handler: async (ctx, { externalId }) => {
     // should this check be in the "controller"?
     const webhook = await ctx.runQuery(internal.lib.replicate.getEntry, { externalId: externalId });
     if (!webhook) {
@@ -74,7 +74,7 @@ export const processWebhook = internalAction({
 
 export const enqueueBackgroundMusicGeneration = internalAction({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     if (!replicateAvailable()) {
       return;
     }
@@ -106,7 +106,7 @@ export const createEntry = internalMutation({
     handler: v.string(), //handler defines the function to use when Replicate POST back to server
     input: v.any(),
   },
-  handler: async (ctx, { externalId, handler, input, ...args }) => {
+  handler: async (ctx, { externalId, handler, input }) => {
     const webhookId = await ctx.db.insert('replicate_webhooks', {
       externalId,
       handler,
@@ -120,7 +120,7 @@ export const getEntry = internalQuery({
   args: {
     externalId: v.string(),
   },
-  handler: async (ctx, { externalId, ...args }) => {
+  handler: async (ctx, { externalId }) => {
     const webhook = await ctx.db
       .query('replicate_webhooks')
       .filter((entry) => entry.eq(entry.field('externalId'), externalId))

--- a/convex/lib/replicate.ts
+++ b/convex/lib/replicate.ts
@@ -19,7 +19,7 @@ export function replicateAvailable(): boolean {
   return !!process.env.REPLICATE_API_TOKEN;
 }
 export const handleReplicateWebhook = httpAction(async (ctx, request) => {
-  const req = await request.json();
+  const req = await request.json() as {id: string};
   if (req.id) {
     await ctx.scheduler.runAfter(0, internal.lib.replicate.processWebhook, {
       externalId: req.id,
@@ -29,7 +29,7 @@ export const handleReplicateWebhook = httpAction(async (ctx, request) => {
 });
 
 async function backgroundMusicGenHandler(prediction: Prediction, ctx: ActionCtx) {
-  const response = await fetch(prediction.output);
+  const response = await fetch(prediction.output as string);
   const music = await response.blob();
 
   // TODO figure out why .store is returning a Promise<string> and not Promise<Id<'storage'>>
@@ -110,7 +110,7 @@ export const createEntry = internalMutation({
     const webhookId = await ctx.db.insert('replicate_webhooks', {
       externalId,
       handler,
-      input,
+      input: input as unknown,
     });
     return webhookId;
   },

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -1,5 +1,5 @@
 import { Validator, v } from 'convex/values';
-import { WithoutSystemFields, defineTable } from 'convex/server';
+import { defineTable } from 'convex/server';
 import { Doc, Id, TableNames } from '../_generated/dataModel';
 import { DatabaseReader } from '../_generated/server';
 

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -33,7 +33,7 @@ export async function asyncMap<FromType, ToType>(
 }
 
 /**
- * asyncFilter returns the results of applying an async function over an list.
+ * asyncFilter returns the results of filtering a list by an async function.
  *
  * @param list - Iterable object of items, e.g. an Array, Set, Object.keys
  * @param asyncTransform
@@ -43,7 +43,7 @@ export async function asyncFilter<T>(
   list: Iterable<T>,
   asyncTransform: (item: T, index: number) => Promise<any>,
 ): Promise<T[]> {
-  const promises: Promise<boolean>[] = [];
+  const promises: Promise<any>[] = [];
   const results: T[] = [];
   let idx = 0;
   for (const item of list) {
@@ -65,7 +65,7 @@ export async function getAll<TableName extends TableNames>(
   db: DatabaseReader,
   ids: Id<TableName>[],
 ): Promise<Doc<TableName>[]> {
-  const docs = await asyncMap(ids, db.get);
+  const docs = await asyncMap(ids, (id) => db.get(id));
   return docs.map((doc, idx) => {
     if (doc === null) {
       throw new Error(`Missing document for id ${ids[idx]}`);

--- a/convex/music.ts
+++ b/convex/music.ts
@@ -6,7 +6,7 @@ export const createMusic = internalMutation({
     storageId: v.string(),
     type: v.union(v.literal('background'), v.literal('player')),
   },
-  handler: async (ctx, { storageId, type, ...args }) => {
+  handler: async (ctx, { storageId, type }) => {
     const music = await ctx.db.insert('music', {
       storageId,
       type,
@@ -17,7 +17,7 @@ export const createMusic = internalMutation({
 
 export const getBackgroundMusic = query({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const music = await ctx.db
       .query('music')
       .filter((entry) => entry.eq(entry.field('type'), 'background'))

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -9,7 +9,7 @@ import { internal } from './_generated/api';
 
 export const getWorld = query({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     // Future: based on auth, fetch the user's world
     const world = await ctx.db.query('worlds').order('desc').first();
     if (!world) {

--- a/convex/testing.ts
+++ b/convex/testing.ts
@@ -15,7 +15,7 @@ import { findRoute } from './lib/routing';
 
 export const converge = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const world = await ctx.db.query('worlds').order('desc').first();
     if (!world) throw new Error('No worlds exist yet: try running dbx convex run init');
     const players = await getAllPlayers(ctx.db, world._id);
@@ -31,7 +31,7 @@ export const converge = internalMutation({
 
 export const stopThinking = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const world = (await ctx.db.query('worlds').order('desc').first())!;
     const agents = await ctx.db
       .query('agents')
@@ -45,7 +45,7 @@ export const stopThinking = internalMutation({
 
 export const testRouteFinding = internalQuery({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const map = (await ctx.db.query('maps').order('desc').first())!;
     const startMotion: Motion = {
       type: 'stopped',
@@ -83,7 +83,7 @@ export const debugAgentSnapshotWithThinking = internalMutation({
 
 export const agentState = internalQuery({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const world = await ctx.db.query('worlds').order('desc').first();
     if (!world) throw new Error('No worlds exist yet: try running dbx convex run init');
     const agents = await ctx.db
@@ -107,7 +107,7 @@ export const getDebugPlayers = internalQuery({
 
 export const allPlayers = internalQuery({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const players = await ctx.db.query('players').collect();
     if (!players) return null;
     return asyncMap(players, (p) => getPlayer(ctx.db, p));
@@ -116,7 +116,7 @@ export const allPlayers = internalQuery({
 
 export const latestPlayer = internalQuery({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const player = await ctx.db.query('players').order('desc').first();
     if (!player) return null;
     return getPlayer(ctx.db, player);
@@ -132,7 +132,7 @@ export const debugPlayerIdSnapshot = internalQuery({
 
 export const listMessages = internalQuery({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const world = await ctx.db.query('worlds').order('desc').first();
     if (!world) return [];
     const players = await getAllPlayers(ctx.db, world._id);
@@ -183,12 +183,12 @@ export const runAgentLoop = internalAction({
   },
   handler: async (ctx, args) => {
     console.log('Looping', args.numberOfLoops || 100);
-    const { players, world } = await ctx.runQuery(internal.testing.getDebugPlayers);
+    const { players } = await ctx.runQuery(internal.testing.getDebugPlayers);
     const playerIds = players.map((p) => p.id);
 
     let index = args.numberOfLoops || 100;
-    let randomX: number[] = [];
-    let displacement = 25;
+    const randomX: number[] = [];
+    const displacement = 25;
     for (let i = 0; i < playerIds.length; i++) {
       randomX.push(displacement * i);
     }
@@ -223,7 +223,7 @@ export const runConversation = internalAction({
     conversationCount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const { players, world } = await ctx.runQuery(internal.testing.getDebugPlayers);
+    const { players } = await ctx.runQuery(internal.testing.getDebugPlayers);
     const memory = MemoryDB(ctx);
     for (let i = 0; i < (args.conversationCount ?? 1); i++) {
       await handleAgentInteraction(ctx, players, memory, async (agentId, activity) => {
@@ -235,7 +235,7 @@ export const runConversation = internalAction({
 
 export const debugClearAll = internalMutation({
   args: {},
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     for (const table in schema.tables) {
       await ctx.scheduler.runAfter(0, internal.crons.vacuumOldEntries, {
         table: table as TableNames,

--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,13 @@
 /** @type {import('next').NextConfig} */
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
 const nextConfig = {
   basePath: '/ai-town',
   experimental: {
     serverActions: true,
   },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     // Adjust the path to match the location of your "AI-town" project
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,11 @@
 /** @type {import('next').NextConfig} */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
 const nextConfig = {
   basePath: '/ai-town',
   experimental: {
     serverActions: true,
   },
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     // Adjust the path to match the location of your "AI-town" project
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,6 @@
         "@types/node": "20.2.5",
         "@types/react": "18.2.8",
         "@types/react-dom": "18.2.4",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
         "autoprefixer": "10.4.14",
         "clsx": "^2.0.0",
         "convex": "^1.0.3",
@@ -43,6 +41,8 @@
         "@flydotio/dockerfile": "^0.2.14",
         "@types/css-font-loading-module": "^0.0.8",
         "@types/ws": "^8.5.5",
+        "@typescript-eslint/eslint-plugin": "^6.4.1",
+        "@typescript-eslint/parser": "^6.4.1",
         "concurrently": "^8.2.0",
         "npm-run-all": "^4.1.5"
       }
@@ -1077,7 +1077,8 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1154,7 +1155,8 @@
     "node_modules/@types/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
@@ -1185,31 +1187,33 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.1.tgz",
+      "integrity": "sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==",
+      "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/type-utils": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.4.1",
+        "@typescript-eslint/type-utils": "6.4.1",
+        "@typescript-eslint/utils": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1217,30 +1221,153 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
+      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
+      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
+      "integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.4.1",
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
+      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
+      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
+      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -1260,29 +1387,87 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.1.tgz",
+      "integrity": "sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==",
+      "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
+        "@typescript-eslint/typescript-estree": "6.4.1",
+        "@typescript-eslint/utils": "6.4.1",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
+      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
+      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -1324,28 +1509,102 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
+      "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.4.1",
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.4.1",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
+      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
+      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
+      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.4.1",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -2832,6 +3091,32 @@
         }
       }
     },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/parser": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -3065,26 +3350,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-scope/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -4415,11 +4680,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
-    },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g=="
     },
     "node_modules/next": {
       "version": "13.4.4",
@@ -6019,6 +6279,18 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "npm-run-all dev:init --parallel dev:frontend dev:backend",
     "build": "tsc && next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "dev:backend": "convex dev",
     "dev:frontend": "next dev",
     "dev:init": "convex dev --run init --until-success"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "@types/node": "20.2.5",
     "@types/react": "18.2.8",
     "@types/react-dom": "18.2.4",
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
     "autoprefixer": "10.4.14",
     "clsx": "^2.0.0",
     "convex": "^1.0.3",
@@ -47,6 +45,8 @@
     "@flydotio/dockerfile": "^0.2.14",
     "@types/css-font-loading-module": "^0.0.8",
     "@types/ws": "^8.5.5",
+    "@typescript-eslint/eslint-plugin": "^6.4.1",
+    "@typescript-eslint/parser": "^6.4.1",
     "concurrently": "^8.2.0",
     "npm-run-all": "^4.1.5"
   }

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -87,7 +87,9 @@ const useServerTimeOffset = (worldId: Id<'worlds'> | undefined) => {
       setOffset(avgOffset);
     };
     void updateOffset();
-    const interval = setInterval(updateOffset, HEARTBEAT_PERIOD);
+    const interval = setInterval(() => {
+      void updateOffset();
+    }, HEARTBEAT_PERIOD);
     return () => clearInterval(interval);
   }, [worldId]);
   return offset;

--- a/src/components/MusicButton.tsx
+++ b/src/components/MusicButton.tsx
@@ -24,7 +24,7 @@ export default function MusicButton() {
     if (isPlaying) {
       sound.stop('background');
     } else {
-      sound.play('background');
+      await sound.play('background');
     }
     setPlaying(!isPlaying);
   };
@@ -32,7 +32,7 @@ export default function MusicButton() {
   const handleKeyPress = useCallback(
     (event: { key: string }) => {
       if (event.key === 'm' || event.key === 'M') {
-        flipSwitch();
+        void flipSwitch();
       }
     },
     [flipSwitch],
@@ -50,7 +50,9 @@ export default function MusicButton() {
     <>
       <a
         className="button text-white shadow-solid text-2xl pointer-events-auto"
-        onClick={flipSwitch}
+        onClick={() => {
+          void flipSwitch();
+        }}
         title="Play AI generated music (press m to play/mute)"
       >
         <div className="inline-block bg-clay-700">

--- a/src/components/PixiViewport.tsx
+++ b/src/components/PixiViewport.tsx
@@ -11,6 +11,7 @@ const PixiViewportComponent = PixiComponent('Viewport', {
     const { app, ...viewportProps } = props;
 
     const viewport = new Viewport({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       events: app.renderer.events,
       passiveWheel: false,
       ...viewportProps,
@@ -34,6 +35,7 @@ const PixiViewportComponent = PixiComponent('Viewport', {
     Object.keys(newProps).forEach((p) => {
       if (p !== 'children' && oldProps[p] !== newProps[p]) {
         // @ts-expect-error Ignoring TypeScript here
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         viewport[p] = newProps[p];
       }
     });


### PR DESCRIPTION
1. make `npm run lint` run the lint rules specified in the eslint config, instead of unrelated rules.
2. adjust the eslint config to allow patterns which are being used and should be usable safely, like unused variables starting with underscore.
3. fix remaining lint warnings and errors.