### PR TITLE
reduce thinking timeout

### DIFF
--- a/convex/config.ts
+++ b/convex/config.ts
@@ -5,7 +5,7 @@ export const CLOSE_DISTANCE = 1;
 // How long it takes a player to walk one tile.
 export const TIME_PER_STEP = 2_000;
 // After this many ms, give up on the agent and start thinking again.
-export const AGENT_THINKING_TOO_LONG = 600_000;
+export const AGENT_THINKING_TOO_LONG = 60_000;
 // How long to hang out if there was no path to your destination.
 export const STUCK_CHILL_TIME = 30_000;
 // How long to let a conversation go on for with agents


### PR DESCRIPTION
it's not uncommon, especially when some api is misconfigured, for all agents to end up in the "thinking" state.
then they look stuck. there aren't any errors in the console or convex dashboard. they're just thinking at each other aggressively.
even after you fix the misconfiguration, they will still think at each other for 10 minutes, so it's hard to tell that things are fixed. we can reduce this delay to 1 minute.

there may be worries that an agent is waiting on a slow openai call, and we shouldn't be preempting them if it's going to succeed. but if the call is taking more than a minute, it's probably not going to succeed anyway.