### PR TITLE
Add comment describing context workaround.

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -35,6 +35,8 @@ export const Game = ({
           worldHeight={worldState.map.tileSetDim}
         >
           <PixiStaticMap map={worldState.map}></PixiStaticMap>
+          {/* Re-propagate context because contexts are not shared between renderers.
+https://github.com/michalochman/react-pixi-fiber/issues/145#issuecomment-531549215 */}
           <ConvexProvider client={convex}>
             {players.map((player) => (
               <Player


### PR DESCRIPTION
This was confusing before: Pixi uses a custom reconciler/renderer and the new React Convex API doesn't work across different ones of these.