### PR TITLE
fix clock skew calculation

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -79,11 +79,11 @@ const useServerTimeOffset = (worldId: Id<'worlds'> | undefined) => {
       prev.current.push(newOffset);
       if (prev.current.length > 5) prev.current.shift();
       const rollingOffset =
-        prev.current.length === 1
+        prev.current.length < 3
           ? prev.current
           : // Take off the max & min as outliers
             [...prev.current].sort().slice(1, -1);
-      const avgOffset = rollingOffset.reduce((a, b) => a + b, 0) / prev.current.length;
+      const avgOffset = rollingOffset.reduce((a, b) => a + b, 0) / rollingOffset.length;
       setOffset(avgOffset);
     };
     void updateOffset();


### PR DESCRIPTION
the characters are glitching a lot, because clock skew calculation has a couple problems:

1. if there are exactly two clock skew data points, we consider them both outliers and say clock skew is 0.
2. if there are n > 2 clock skew data points, we calculate the average by adding up n-2 points (excluding two outliers) and dividing by n. so if the data points are -8700, -8800, -8900 (which are the numbers i'm seeing) then we say clock skew is -2933.

this is a devious bug because for the first 30 seconds everything looks great, then clock skew estimation plummets, and after a few minutes it's back to a reasonable estimate.