### PR TITLE
smooth walking when changing plan

### DIFF
--- a/convex/lib/physics.ts
+++ b/convex/lib/physics.ts
@@ -103,9 +103,21 @@ export function roundPosition(pos: Position): Position {
 }
 
 export function roundPose(pose: Pose): Pose {
+  const p = pose.position;
+  // Degress counter-clockwise from East/Right
+  const orientation = 90 * Math.round(pose.orientation / 90);
+  // Round in the direction of movement.
+  const position =
+    orientation === 0
+      ? { x: Math.ceil(p.x), y: Math.round(p.y) } // right
+      : orientation === 90
+      ? { x: Math.round(p.x), y: Math.floor(p.y) } // up
+      : orientation === 180
+      ? { x: Math.floor(p.x), y: Math.round(p.y) } // left
+      : { x: Math.round(p.x), y: Math.ceil(p.y) }; // down
   return {
-    position: roundPosition(pose.position),
-    orientation: 90 * Math.round(pose.orientation / 90),
+    position,
+    orientation,
   };
 }
 

--- a/convex/lib/physics.ts
+++ b/convex/lib/physics.ts
@@ -98,10 +98,6 @@ export function getRouteDistance(route: Position[]): number {
   }, 0);
 }
 
-export function roundPosition(pos: Position): Position {
-  return { x: Math.round(pos.x), y: Math.round(pos.y) };
-}
-
 export function roundPose(pose: Pose): Pose {
   const p = pose.position;
   // Degress counter-clockwise from East/Right


### PR DESCRIPTION
when a character goes from one walking on one path to walking on another, we can make the transition smooth instead of rounding to the nearest integer location first.
we do this by using the current fractional position as the start of the new path, adding the little extra distance to every path, and the integer we're aiming for now takes into account our orientation.

this doesn't affect the NPCs very much, since they only do one walk at a time. but it helps a lot when we allow interaction to override paths. when you transition from walking on one path to another, there's no longer a little jump.