### PR TITLE
stream chat completions

### DIFF
--- a/convex/chat.ts
+++ b/convex/chat.ts
@@ -86,6 +86,7 @@ export function clientMessageMapper(db: DatabaseReader) {
   const getName = async (id: Id<'players'>) => (await db.get(id))?.name || '<Anonymous>';
   const clientMessage = async (m: MessageEntry): Promise<Message> => {
     const common = {
+      entryId: m._id,
       from: m.playerId,
       fromName: await getName(m.playerId),
       to: m.data.audience,

--- a/convex/conversation.ts
+++ b/convex/conversation.ts
@@ -41,7 +41,8 @@ export async function startConversation(
   ];
   const stop = stopWords(newFriendsNames);
   const { content } = await chatCompletion({ messages: prompt, max_tokens: 300, stop });
-  return { content: trimContent(content, stop), memoryIds: memories.map((m) => m.memory._id) };
+  const contentStr = await content.readAll();
+  return { content: contentStr, memoryIds: memories.map((m) => m.memory._id) };
 }
 
 function messageContent(m: Message): string {
@@ -58,24 +59,6 @@ function messageContent(m: Message): string {
 // These are the words we ask the LLM to stop on. OpenAI only supports 4.
 function stopWords(names: string[]): string[] {
   return names.flatMap((name) => [name + ':', name.toLowerCase() + ':']);
-}
-
-// As a stopgap since the stop sequences don't always work, we trim the output
-// based on the first stop word we find, lowercased.
-function trimContent(content: string, stopWords: string[]) {
-  let foundWordAtIndex = -1;
-  const contentLower = content.toLowerCase();
-  stopWords.forEach((word) => {
-    const idx = contentLower.indexOf(word.toLowerCase());
-    if (idx > -1 && (foundWordAtIndex === -1 || idx < foundWordAtIndex)) {
-      foundWordAtIndex = idx;
-      console.debug('found stop word, trimming content', word, idx);
-    }
-  });
-  if (foundWordAtIndex > -1) {
-    return content.slice(0, foundWordAtIndex);
-  }
-  return content;
 }
 
 export function chatHistoryFromMessages(messages: Message[]): LLMMessage[] {
@@ -114,7 +97,7 @@ export async function decideWhoSpeaksNext(
   const { content } = await chatCompletion({ messages: prompt, max_tokens: 300 });
   let speakerId: string | undefined = undefined;
   try {
-    const contentJSON = JSON.parse(content) as { id: string };
+    const contentJSON = JSON.parse(await content.readAll()) as { id: string };
     speakerId = contentJSON.id;
   } catch (e) {
     console.error('error parsing speakerId: ', e);
@@ -188,7 +171,7 @@ export async function converse(
   const stop = stopWords(nearbyPlayers.map((p) => p.name));
   const { content } = await chatCompletion({ messages: prompt, max_tokens: 300, stop });
   // console.debug('converse result through chatgpt: ', content);
-  return { content: trimContent(content, stop), memoryIds: memories.map((m) => m.memory._id) };
+  return { content: await content.readAll(), memoryIds: memories.map((m) => m.memory._id) };
 }
 
 export async function walkAway(messages: LLMMessage[], player: Player): Promise<boolean> {
@@ -206,5 +189,5 @@ export async function walkAway(messages: LLMMessage[], player: Player): Promise<
     max_tokens: 1,
     temperature: 0,
   });
-  return description === '1';
+  return await description.readAll() === '1';
 }

--- a/convex/conversation.ts
+++ b/convex/conversation.ts
@@ -41,8 +41,7 @@ export async function startConversation(
   ];
   const stop = stopWords(newFriendsNames);
   const { content } = await chatCompletion({ messages: prompt, max_tokens: 300, stop });
-  const contentStr = await content.readAll();
-  return { content: contentStr, memoryIds: memories.map((m) => m.memory._id) };
+  return { content, memoryIds: memories.map((m) => m.memory._id) };
 }
 
 function messageContent(m: Message): string {
@@ -171,7 +170,7 @@ export async function converse(
   const stop = stopWords(nearbyPlayers.map((p) => p.name));
   const { content } = await chatCompletion({ messages: prompt, max_tokens: 300, stop });
   // console.debug('converse result through chatgpt: ', content);
-  return { content: await content.readAll(), memoryIds: memories.map((m) => m.memory._id) };
+  return { content, memoryIds: memories.map((m) => m.memory._id) };
 }
 
 export async function walkAway(messages: LLMMessage[], player: Player): Promise<boolean> {

--- a/convex/journal.ts
+++ b/convex/journal.ts
@@ -187,6 +187,21 @@ export const talk = internalMutation({
   },
 });
 
+export const talkMore = internalMutation({
+  args: {
+    entryId: v.id('journal'),
+    content: v.string(),
+  },
+  handler: async (ctx, { entryId, content }) => {
+    const data = (await ctx.db.get(entryId))!.data;
+    if (data.type === 'talking') {
+      data.content += content;
+    }
+    await ctx.db.patch(entryId, { data });
+    return await clientMessageMapper(ctx.db)((await ctx.db.get(entryId))! as MessageEntry);
+  },
+});
+
 export const leaveConversation = internalMutation({
   args: {
     playerId: v.id('players'),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -40,6 +40,7 @@ export const Pose = v.object({ position: Position, orientation: v.number() });
 export type Pose = Infer<typeof Pose>;
 
 const commonFields = {
+  entryId: v.id('journal'),
   from: v.id('players'),
   fromName: v.string(),
   to: v.array(v.id('players')),


### PR DESCRIPTION
stream content from chatgpt chat completions into ai-town.
this exercises streaming fetches in convex that is so hot-off-the-presses that it doesn't actually work yet. still, looks good.

https://github.com/get-convex/ai-town/assets/4319355/51064abe-73cc-4d21-a3ff-da5d5b537c21

note i don't think we need the `trimContent` because we're also adding lowercased stop tokens, and i haven't had any problems when i remove it. also it's annoying to implement on streamed data
