### PR TITLE
debounce streamed conversations

### DIFF
--- a/convex/journal.ts
+++ b/convex/journal.ts
@@ -195,7 +195,7 @@ export const talkMore = internalMutation({
   handler: async (ctx, { entryId, content }) => {
     const data = (await ctx.db.get(entryId))!.data;
     if (data.type === 'talking') {
-      data.content += content;
+      data.content = content;
     }
     await ctx.db.patch(entryId, { data });
     return await clientMessageMapper(ctx.db)((await ctx.db.get(entryId))! as MessageEntry);


### PR DESCRIPTION
add debouncing to streamed conversation mutations. so if the streaming is fast but mutations are slow, we send fewer mutations.