### PR TITLE
Tweak PlayerDetails view

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ See more functions in [`testing.ts`](./convex/testing.ts).
 
 #### Deploy to Vercel
 
-TODO
+Deploy this app to Vercel with just `vercel` (and then `vercel --prod` to deploy to production).
+
+You may have to sign up for a Vercel account and install the Vercel CLI with `npm install --global vercel`.
 
 #### Deploy Convex functions to prod environment
 

--- a/assets/close.svg
+++ b/assets/close.svg
@@ -1,0 +1,18 @@
+<svg width="5" height="5" viewBox="0 0 5 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_26_240)">
+<rect x="0" y="0" width="1" height="1" fill="white"/>
+<rect x="1" y="1" width="1" height="1" fill="white"/>
+<rect x="2" y="2" width="1" height="1" fill="white"/>
+<rect x="3" y="3" width="1" height="1" fill="white"/>
+<rect x="4" y="4" width="1" height="1" fill="white"/>
+<rect x="3" y="1" width="1" height="1" fill="white"/>
+<rect x="4" y="0" width="1" height="1" fill="white"/>
+<rect x="0" y="4" width="1" height="1" fill="white"/>
+<rect x="1" y="3" width="1" height="1" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_26_240">
+<rect width="5" height="5" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -135,12 +135,8 @@ export const leaveMyCurrentConversation = mutation({
         audience: conversation.audience,
         conversationId: conversation.conversationId,
       },
-    });
-    try {
-      await ctx.db.patch(playerId, { controllerThinking: undefined });
-    } catch (e) {
-      // It's okay if the player has been deleted.
-    }
+    })
+    await ctx.db.patch(playerId, { controllerThinking: undefined });;
   }
 })
 

--- a/convex/agent.ts
+++ b/convex/agent.ts
@@ -100,8 +100,7 @@ export const runAgentBatch = internalAction({
 });
 
 export const myCurrentConversation = query({
-  args: { preferredPlayerId: v.optional(v.id("players")) },
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
     const me = await activePlayer(ctx.auth, ctx.db);
     if (!me) {
       return null;
@@ -114,10 +113,7 @@ export const myCurrentConversation = query({
     if (notMe.length === 0) {
       return null;
     }
-    if (args.preferredPlayerId && notMe.includes(args.preferredPlayerId)) {
-      return args.preferredPlayerId;
-    }
-    return notMe[0];
+    return notMe;
   }
 })
 

--- a/convex/journal.ts
+++ b/convex/journal.ts
@@ -59,6 +59,7 @@ export async function getPlayer(db: DatabaseReader, playerDoc: Doc<'players'>) {
     lastChat: latestConversation && {
       message: await clientMessageMapper(db)(latestConversation),
       conversationId: latestConversation.data.conversationId,
+      audience: latestConversation.data.audience,
     },
   };
 }
@@ -216,7 +217,7 @@ export const userTalk = mutation({
       playerId: player.id,
       data: {
         type: 'talking',
-        audience: [],
+        audience: player.lastChat.audience,
         conversationId: player.lastChat.conversationId,
         content: userInput.content,
         relatedMemoryIds: [],

--- a/src/components/GameWrapper.tsx
+++ b/src/components/GameWrapper.tsx
@@ -1,21 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import PlayerDetails from './PlayerDetails.tsx';
 import Game from './Game.tsx';
 
 import { useElementSize } from 'usehooks-ts';
 import { Id } from '../../convex/_generated/dataModel';
-import { useMutation } from 'convex/react';
-import { api } from '../../convex/_generated/api';
 
 export default function GameWrapper() {
   const [selectedPlayer, setSelectedPlayer] = useState<Id<'players'>>();
-  const talkToMe = useMutation(api.agent.talkToMe);
   const [gameWrapperRef, { width, height }] = useElementSize();
-  useEffect(() => {
-    if (selectedPlayer) {
-      void talkToMe({playerId: selectedPlayer});
-    }
-  }, [selectedPlayer]);
   return (
     <div className="mx-auto w-full max-w mt-7 grid grid-rows-[240px_1fr] lg:grid-rows-[1fr] lg:grid-cols-[1fr_auto] lg:h-[700px] max-w-[1400px] min-h-[480px] game-frame">
       {/* Game area */}
@@ -27,13 +19,7 @@ export default function GameWrapper() {
 
       {/* Right column area */}
       <div className="flex flex-col overflow-y-auto shrink-0 px-4 py-6 sm:px-6 lg:w-96 xl:pr-6 bg-brown-800 text-brown-100">
-        {selectedPlayer ? (
-          <PlayerDetails playerId={selectedPlayer} />
-        ) : (
-          <div className="h-full text-xl flex text-center items-center p-4">
-            Click on an agent on the map to see chat history.
-          </div>
-        )}
+        <PlayerDetails playerId={selectedPlayer} setSelectedPlayer={setSelectedPlayer} />
       </div>
     </div>
   );

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -10,7 +10,7 @@ import { Character } from './Character.tsx';
 const SpeechDurationMs = 2000;
 const SpokeRecentlyMs = 5_000;
 
-export type SelectPlayer = (playerId: Id<'players'>) => void;
+export type SelectPlayer = (playerId?: Id<'players'>) => void;
 
 export const Player = ({
   player,

--- a/src/components/PlayerDetails.tsx
+++ b/src/components/PlayerDetails.tsx
@@ -115,12 +115,13 @@ function MessageInput({
 }
 
 // TODO: Add feedback when the agent is on their way
-// TODO: Don't rerender `PlayerDetails` when in a conversation and clicking on someone else.
 export default function PlayerDetails({ playerId, setSelectedPlayer }: { playerId?: Id<'players'>, setSelectedPlayer: SelectPlayer }) {
-  const currentConversation = useQuery(api.agent.myCurrentConversation, { preferredPlayerId: playerId });
-  const inConversation = currentConversation !== undefined && currentConversation !== null;
+  const currentConversationPlayers = useQuery(api.agent.myCurrentConversation, {});
+  const inConversation = currentConversationPlayers !== undefined && currentConversationPlayers !== null;
   if (inConversation) {
-    playerId = currentConversation;
+    if (!playerId || !currentConversationPlayers.includes(playerId)) {
+      playerId = currentConversationPlayers[0];
+    }
   }
   const playerState = useQuery(api.players.playerState, playerId ? { playerId } : "skip");
   const playerDetails = useQuery(api.agent.playerDetails, playerId ? { playerId } : "skip");
@@ -132,8 +133,6 @@ export default function PlayerDetails({ playerId, setSelectedPlayer }: { playerI
         Click on an agent on the map to see chat history.
       </div>
     )
-  } else {
-
   }
   return (
     playerId && playerState && playerDetails !== undefined && (


### PR DESCRIPTION
Disallow talking to other humans.

Add a close button to the conversation pane that goes back to the initial view and leaves a current conversation (if relevant):
![image](https://github.com/get-convex/ai-town/assets/5784949/65892aaa-e2cb-4317-ade7-262c354e5f48)

Add feedback for when the player detail view is for an agent we're currently talking to.
![image](https://github.com/get-convex/ai-town/assets/5784949/13e78665-9ecb-485a-874c-3da6ac579cdd) 

Add a button to start a conversation with AI agents that aren't in one already.
![image](https://github.com/get-convex/ai-town/assets/5784949/3bc8753a-c098-400b-b8a3-58955aa63095)

We show some feedback when the agent is walking over.
![image](https://github.com/get-convex/ai-town/assets/5784949/9cbc3dcb-71ca-4581-8b2f-7c8940790fb1)

Change the message for when you're looking at yourself.
![image](https://github.com/get-convex/ai-town/assets/5784949/e8e06521-b9ce-459b-af4c-c40f86e72013)
