### PR TITLE
Add a waitlist

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -49,6 +49,7 @@ import type * as maps_firstmap from "../maps/firstmap";
 import type * as music from "../music";
 import type * as players from "../players";
 import type * as testing from "../testing";
+import type * as waitlist_constants from "../waitlist_constants";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -94,6 +95,7 @@ declare const fullApi: ApiFromModules<{
   music: typeof music;
   players: typeof players;
   testing: typeof testing;
+  waitlist_constants: typeof waitlist_constants;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -213,4 +213,9 @@ crons.interval(
   { minutes: 5 },
   internal.crons.vacuumAbandonedInteractions,
 );
+crons.interval(
+  'kick out players',
+  { minutes: 5 },
+  internal.players.kickPlayers,
+)
 export default crons;

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -1,6 +1,6 @@
 import { v } from 'convex/values';
 import { Doc, Id } from './_generated/dataModel';
-import { DatabaseReader, mutation, query } from './_generated/server';
+import { DatabaseReader, DatabaseWriter, MutationCtx, internalMutation, mutation, query } from './_generated/server';
 import { enqueueAgentWake } from './engine';
 import { HEARTBEAT_PERIOD, WORLD_IDLE_THRESHOLD } from './config';
 import { Characters, Player, Pose } from './schema';
@@ -8,6 +8,7 @@ import { getPlayer, walkToTarget } from './journal';
 import { internal } from './_generated/api';
 import { getPoseFromMotion, roundPose } from './lib/physics';
 import { Auth } from 'convex/server';
+import { MAX_HUMANS, MAX_PLAYTIME, WAITLIST_DEADLINE } from './waitlist_constants';
 
 export const activeWorld = async (db: DatabaseReader) => {
   // Future: based on auth, fetch the user's world
@@ -189,6 +190,75 @@ export const createCharacter = mutation({
   },
 });
 
+export const waitlistStatus = query({
+  args: {
+    worldId: v.id("worlds"),
+  },
+  handler: async (ctx, args) => {
+    const first = await ctx.db.query("waitlist")
+      .withIndex("ticket", q => q.eq("worldId", args.worldId))
+      .order("asc")
+      .first();
+    const last = await ctx.db.query("waitlist")
+      .withIndex("ticket", q => q.eq("worldId", args.worldId))
+      .order("desc")
+      .first();
+
+    let ticketNumber: number | undefined;
+    const userIdentity = await ctx.auth.getUserIdentity();
+    if (userIdentity) {
+      const existingWaitlist = await ctx.db.query("waitlist")
+        .withIndex("subject", q => q.eq("worldId", args.worldId).eq("tokenIdentifier", userIdentity.tokenIdentifier))
+        .first();
+      ticketNumber = existingWaitlist?.ticket;
+    }
+    return {
+      firstTicket: first?.ticket ?? null,
+      lastTicket: last?.ticket ?? null,
+
+      ticketNumber: ticketNumber ?? null,
+
+      serverNow: Date.now(),
+      firstDeadline: first?.deadline ?? null,
+
+      maxHumans: MAX_HUMANS,
+    };
+  }
+})
+
+export const kickPlayers = internalMutation({
+  handler: async (ctx) => {
+    const world = await activeWorld(ctx.db);
+    if (!world) {
+      console.warn("No active world");
+      return;
+    }
+    if (world.frozen) {
+      return;
+    }
+    const allPlayers = await ctx.db.query("players")
+        .withIndex("by_worldId", q => q.eq("worldId", world._id))
+        .collect();
+    const humanAgents = allPlayers
+      .filter(p => p.controller !== undefined);
+
+    const firstWaitlist = await ctx.db.query("waitlist")
+      .withIndex("ticket", q => q.eq("worldId", world._id))
+      .first();
+    if (firstWaitlist == null) {
+      return;
+    }
+    console.log("Pruning players since there's a waitlist");
+    const now = Date.now();
+    for (const player of humanAgents) {
+      if (now - player._creationTime > MAX_PLAYTIME) {
+        console.log("Kicking out", player._id);
+        await deletePlayer(ctx, player._id);
+      }
+    }
+  }
+})
+
 export const createPlayer = mutation({
   args: {
     pose: Pose,
@@ -198,6 +268,9 @@ export const createPlayer = mutation({
   },
   handler: async (ctx, { name, characterId, pose, forUser }) => {
     const world = await activeWorld(ctx.db);
+    if (!world) {
+      throw new Error("No currently active world");
+    }
     let controller = undefined;
     if (forUser) {
       const activePlayer = await activePlayerDoc(ctx.auth, ctx.db);
@@ -208,20 +281,72 @@ export const createPlayer = mutation({
       if (!userIdentity) {
         throw new Error('must be logged in to make an interacting player');
       }
-      controller = userIdentity.tokenIdentifier;
+
+      const allPlayers = await ctx.db.query("players")
+        .withIndex("by_worldId", q => q.eq("worldId", world._id))
+        .collect();
+      const humanAgents = allPlayers
+        .filter(p => p.controller !== undefined)
+        .reduce((a, _) => a + 1, 0);
+
+      // Expire the head of the waitlist if it's past its deadline.
+      let first = await ctx.db.query("waitlist")
+        .withIndex("ticket", q => q.eq("worldId", world._id))
+        .order("asc")
+        .first();
+      if (first && first.deadline && first.deadline < Date.now() && first.tokenIdentifier !== userIdentity.tokenIdentifier) {
+        console.log("Expiring stale queue head", first);
+        await ctx.db.delete(first._id);
+        first = await ctx.db.query("waitlist")
+          .withIndex("ticket", q => q.eq("worldId", world._id))
+          .order("asc")
+          .first();
+        if (first) {
+          first.deadline = Date.now() + WAITLIST_DEADLINE;
+          await ctx.db.replace(first._id, first);
+        }
+      }
+
+      const existingWaitlist = await ctx.db.query("waitlist")
+        .withIndex("subject", q => q.eq("worldId", world._id).eq("tokenIdentifier", userIdentity.tokenIdentifier))
+        .first();
+
+      // Allow the user to join if there's room and either (a) no waitlist or (b) they're at the head of the waitlist.
+      if (humanAgents < MAX_HUMANS && (first === null || first.tokenIdentifier == userIdentity.tokenIdentifier)) {
+        if (first !== null) {
+          await ctx.db.delete(first._id);
+        }
+        controller = userIdentity.tokenIdentifier;
+      }
+      // Otherwise, we're on the waitlist. Insert a row if we weren't on it already.
+      else {
+        if (existingWaitlist) {
+          return { kind: "waitlist", ticketId: existingWaitlist._id };
+        }
+        const lastWaitlist = await ctx.db.query("waitlist")
+          .withIndex("ticket", q => q.eq("worldId", world._id))
+          .order("desc")
+          .first();
+        const ticket = lastWaitlist ? lastWaitlist.ticket + 1 : 0;
+        const ticketId = await ctx.db.insert("waitlist", {
+          worldId: world._id,
+          ticket,
+          tokenIdentifier: userIdentity.tokenIdentifier,
+        });
+        return { kind: "waitlist", ticketId };
+      }
     }
-    // Future: associate this with an authed user
     const playerId = await ctx.db.insert('players', {
       name,
       characterId,
-      worldId: world!._id,
+      worldId: world._id,
       controller,
     });
     await ctx.db.insert('journal', {
       playerId,
       data: { type: 'stopped', reason: 'idle', pose },
     });
-    return playerId;
+    return { kind: "success", playerId };
   },
 });
 
@@ -232,12 +357,37 @@ export const deletePlayer = mutation({
     if (!activePlayer) {
       throw new Error('no player to delete');
     }
-    await ctx.scheduler.runAfter(0, internal.journal.leaveConversation, {
-      playerId: activePlayer._id,
-    });
-    await ctx.db.delete(activePlayer._id);
+    await removePlayer(ctx, activePlayer._id);
   },
 });
+
+async function removePlayer(ctx: MutationCtx, id: Id<"players">) {
+  const activePlayer = await ctx.db.get(id);
+  if (!activePlayer) {
+    throw new Error('no player to delete');
+  }
+  await ctx.scheduler.runAfter(0, internal.journal.leaveConversation, {
+    playerId: activePlayer._id,
+  });
+  await ctx.db.delete(activePlayer._id);
+  const allPlayers = await ctx.db.query("players")
+        .withIndex("by_worldId", q => q.eq("worldId", activePlayer.worldId))
+        .collect();
+  const humanAgents = allPlayers
+    .filter(p => p.controller !== undefined)
+    .reduce((a, _) => a + 1, 0);
+
+  if (humanAgents < MAX_HUMANS) {
+    const first = await ctx.db.query("waitlist")
+      .withIndex("ticket", q => q.eq("worldId", activePlayer.worldId))
+      .order("asc")
+      .first();
+    if (first) {
+      first.deadline = Date.now() + WAITLIST_DEADLINE;
+      await ctx.db.replace(first._id, first);
+    }
+  }
+}
 
 // Future: this could allow creating an agent
 export const createAgent = mutation({

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -301,7 +301,7 @@ export const createPlayer = mutation({
           .withIndex("ticket", q => q.eq("worldId", world._id))
           .order("asc")
           .first();
-        if (first) {
+        if (first && humanAgents < MAX_HUMANS) {
           first.deadline = Date.now() + WAITLIST_DEADLINE;
           await ctx.db.replace(first._id, first);
         }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -302,6 +302,15 @@ export default defineSchema(
       content: v.string(),
       moderationResult: v.optional(v.boolean()),
     }),
+
+    waitlist: defineTable({
+      worldId: v.id('worlds'),
+      ticket: v.float64(),
+      tokenIdentifier: v.string(),
+      deadline: v.optional(v.number()),
+    })
+      .index('ticket', ['worldId', 'ticket'])
+      .index('subject', ['worldId', 'tokenIdentifier']),
   },
   // When schemaValidation is enabled, it prevents pushing code that has a
   // schema incompatible with the current database.

--- a/convex/waitlist_constants.ts
+++ b/convex/waitlist_constants.ts
@@ -1,0 +1,4 @@
+export const MAX_HUMANS = 8;
+export const WAITLIST_DEADLINE = 30 * 1000;
+// Let players play for at most 5m when there's a waitlist.
+export const MAX_PLAYTIME = 5 * 60 * 1000;

--- a/src/components/InteractButton.tsx
+++ b/src/components/InteractButton.tsx
@@ -1,11 +1,37 @@
 import { useQuery, useMutation, useConvexAuth } from 'convex/react';
 import { api } from '../../convex/_generated/api';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useUser } from '@clerk/clerk-react';
 import { characters } from '../../convex/characterdata/data';
 import interactImg from "../../assets/interact.svg";
+import ReactModal from 'react-modal';
 
-export default function InteractButton() {
+type WaitlistStatusFn = typeof api.players.waitlistStatus;
+type WaitlistStatus = WaitlistStatusFn["_returnType"];
+
+const modalStyles = {
+  overlay: {
+    backgroundColor: "rgb(0, 0, 0, 75%)",
+    zIndex: 12,
+  },
+  content: {
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    marginRight: '-50%',
+    transform: 'translate(-50%, -50%)',
+    maxWidth: "50%",
+
+    border: '10px solid rgb(23, 20, 33)',
+    borderRadius: "0",
+    background: 'rgb(35, 38, 58)',
+    color: 'white',
+    fontFamily: '"Upheaval Pro", "sans-serif"',
+  },
+};
+
+export default function InteractButton(props: {waitlistStatus?: WaitlistStatus}) {
   const player = useQuery(api.players.getActivePlayer);
   const navigate = useMutation(api.players.navigateActivePlayer);
   const createCharacter = useMutation(api.players.createCharacter);
@@ -15,6 +41,8 @@ export default function InteractButton() {
   const { user } = useUser();
   const isPlaying = !!player;
 
+  const [waitlistModalOpen, setWaitlistModalOpen] = useState<boolean>(false);
+
   const startPlaying = async () => {
     if (!isAuthenticated || isPlaying || !user) {
       return;
@@ -23,7 +51,7 @@ export default function InteractButton() {
       name: "user",
       spritesheetData: randomSpritesheet(),
     });
-    await createPlayer({
+    const resp = await createPlayer({
       forUser: true,
       name: user.firstName ?? "Me",
       characterId,
@@ -32,6 +60,9 @@ export default function InteractButton() {
         orientation: 1,
       },
     });
+    if (resp.kind === "waitlist") {
+      setWaitlistModalOpen(true);
+    }
   };
 
   const leave = async () => {
@@ -82,9 +113,20 @@ export default function InteractButton() {
   if (!isAuthenticated) {
     return null;
   }
-
+  const onWaitlist = props.waitlistStatus && props.waitlistStatus.ticketNumber !== null;
   return (
     <>
+      {onWaitlist && (
+        <ReactModal
+          isOpen={waitlistModalOpen}
+          onRequestClose={() => setWaitlistModalOpen(false)}
+          style={modalStyles}
+          contentLabel="Waitlist modal"
+          ariaHideApp={false}
+        >
+          <Waitlist waitlistStatus={props.waitlistStatus!} />
+        </ReactModal>
+      )}
       <a
         className="button text-white shadow-solid text-2xl pointer-events-auto"
         onClick={() => {
@@ -100,7 +142,7 @@ export default function InteractButton() {
           <span>
             <div className="inline-flex items-center gap-4">
               <img className="w-[48px] h-[30px] max-w-[54px]" src={interactImg} />
-              {isPlaying ? 'Leave' : 'Interact'}
+              {isPlaying ? 'Leave' : !onWaitlist ? 'Interact' : 'Waitlist'}
             </div>
           </span>
         </div>
@@ -109,7 +151,45 @@ export default function InteractButton() {
   );
 }
 
-const randomSpritesheet = () => {
+function Waitlist(props: {waitlistStatus: WaitlistStatus}) {
+  const { firstTicket, ticketNumber, lastTicket, maxHumans } = props.waitlistStatus;
+
+  if (firstTicket === null || ticketNumber === null || lastTicket === null) {
+    throw new Error(`Invalid waitlist status: ${JSON.stringify(props.waitlistStatus)}`);
+  }
+  const position = ticketNumber - firstTicket;
+  const numTickets = lastTicket - firstTicket;
+  const progressPct = 5 + Math.round((numTickets - position) / numTickets * 95);
+  return (
+    <div className="font-body">
+      <h1 className="text-center text-4xl font-bold font-display game-title">You're on the waitlist!</h1>
+      <p>AI town currently only supports at most {maxHumans} humans at a time.</p>
+
+      <div className="mt-4 ml-4 mr-4 game-progress-bar">
+        <div className="h-4 game-progress-bar-progress" style={{width: `${progressPct}%`}}/>
+      </div>
+
+      {position > 0 && (
+        <p className="mt-4 text-center">
+        You're position {position + 1} of {numTickets + 1} in the queue.
+      </p>
+      )}
+      {position == 0 && (
+        <p className="mt-4 font-bold text-center">
+          You're next up! Waiting for a player to leave...
+        </p>
+      )}
+      <p className="mt-4">
+        Don't want to wait? <a className="font-bold underline" href="https://github.com/get-convex/ai-town/">Fork AI town</a> to create your own game world!
+      </p>
+      <p className="mt-4">
+        (You can close this window to watch conversations going on, and we won't lose your spot. Click "Waitlist" to reopen this window.)
+      </p>
+    </div>
+  )
+}
+
+export const randomSpritesheet = () => {
   const character = characters[Math.floor(Math.random() * characters.length)];
   return character.spritesheetData;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,30 @@ body {
   border-image-slice: 25%;
 }
 
+
+.game-progress-bar {
+  border: 5px solid rgb(23, 20, 33);
+}
+
+@keyframes moveStripes {
+  to {
+    background-position: calc(100% + 28px) 0;
+  }
+}
+
+.game-progress-bar-progress {
+  background: repeating-linear-gradient(
+    135deg,
+    white,
+    white 10px,
+    #dfdfdf 10px,
+    #dfdfdf 20px
+  );
+  background-size: 200% 100%;
+  background-position: 100% 0;
+  animation: moveStripes 0.5s linear infinite;
+}
+
 @media screen and (min-width: 640px) {
   .game-frame {
     border-width: 48px;


### PR DESCRIPTION
The algorithm here is cute (and a great showcase for Convex!):
1. Each world as a waitlist of tickets, where each ticket has a monotonically increasing number.
2. Inserting a ticket queries for the highest number and adds one, fully serializing waitlist insertions.
3. Clients reactively query the smallest and largest tickets from the world, using the index to have a small read set.
4. When a ticket reaches the head of the queue, a countdown starts. Clients have 30s to grab their slot when they're at front.
5. When the client reactively notices it's at the front, it issues a mutation to remove its ticket and create a player.
6. Clients that are not at the front of the queue schedule a mutation for `position * 30s` to dequeue the head of the queue (in case it's gone away)

We then also add a background job to kick players who've been in the world for more than 5m if there are other players waiting.

https://github.com/get-convex/ai-town/assets/5784949/7d2c5848-3a23-4daa-8013-e2eb3df7b782


