### PR TITLE
Fix messages being posted after leaving a conversation

### DIFF
--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -44,9 +44,7 @@ export function Messages({
     );
     return { node, time: m._creationTime };
   });
-  const lastMessageTs = messages
-    .map((m) => m._creationTime)
-    .reduce((a, b) => Math.max(a, b), messages[0]._creationTime);
+  const lastMessageTs = messages.map((m) => m._creationTime).reduce((a, b) => Math.max(a, b), 0);
 
   const membershipNodes: typeof messageNodes = members.flatMap((m) => {
     let started;

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -44,6 +44,10 @@ export function Messages({
     );
     return { node, time: m._creationTime };
   });
+  const lastMessageTs = messages
+    .map((m) => m._creationTime)
+    .reduce((a, b) => Math.max(a, b), messages[0]._creationTime);
+
   const membershipNodes: typeof messageNodes = members.flatMap((m) => {
     let started;
     if (m.status.kind === 'participating' || m.status.kind === 'left') {
@@ -55,7 +59,7 @@ export function Messages({
       out.push({
         node: (
           <div key={`joined-${m._id}`} className="leading-tight mb-6">
-            <p className="text-brown-700 text-center">{m.playerName} joined the conversation</p>
+            <p className="text-brown-700 text-center">{m.playerName} joined the conversation.</p>
           </div>
         ),
         time: started,
@@ -65,10 +69,12 @@ export function Messages({
       out.push({
         node: (
           <div key={`left-${m._id}`} className="leading-tight mb-6">
-            <p className="text-brown-700 text-center">{m.playerName} left the conversation</p>
+            <p className="text-brown-700 text-center">{m.playerName} left the conversation.</p>
           </div>
         ),
-        time: ended,
+        // Always sort all "left" messages after the last message.
+        // TODO: We can remove this once we want to support more than two participants per conversation.
+        time: Math.max(lastMessageTs + 1, ended),
       });
     }
     return out;


### PR DESCRIPTION
I think the bug we were seeing was from an agent's message getting posted after they left the conversation, but I'm not 100% sure. I added the check so we should be able to guarantee messages precede leaving and a resort in the UI just to be sure.