### PR TITLE
tighten up engine start & stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ npx convex run --no-push init:stop
 npx convex run init:resume
 ```
 
+**To kick the engine in case the game engine or agents aren't running**
+
+```bash
+npx convex run init:kick
+```
+
 **To archive the world**
 
 If you'd like to reset the world and start from scratch, you can archive the current world:

--- a/convex/agent/init.ts
+++ b/convex/agent/init.ts
@@ -35,7 +35,7 @@ export const initAgent = internalMutation({
   },
 });
 
-export const restartAgents = internalMutation({
+export const kickAgents = internalMutation({
   args: {
     worldId: v.id('worlds'),
   },

--- a/convex/engine/schema.ts
+++ b/convex/engine/schema.ts
@@ -38,9 +38,18 @@ const engines = v.object({
   // What was `currentTime` for the preceding step of the engine?
   lastStepTs: v.optional(v.number()),
 
-  // Should the engine be running this world? If this is set to false,
-  // the engine will quickly stop simulating the world.
-  active: v.boolean(),
+  // How far has the engine processed in the input queue?
+  processedInputNumber: v.optional(v.number()),
+
+  state: v.union(
+    v.object({
+      kind: v.literal('running'),
+      nextRun: v.number(),
+    }),
+    v.object({
+      kind: v.literal('stopped'),
+    }),
+  ),
 
   // Monotonically increasing counter that allows inputs to restart the engine
   // when it's sleeping. In particular, every scheduled run of the engine
@@ -48,13 +57,6 @@ const engines = v.object({
   // atomically cancel that future execution. This provides mutual exclusion
   // for our core event loop.
   generationNumber: v.number(),
-
-  // Timestamp of the next time we're scheduled. Eventually, this can be the
-  // direct id of the scheduled job.
-  idleUntil: v.number(),
-
-  // How far has the engine processed in the input queue?
-  processedInputNumber: v.optional(v.number()),
 });
 
 export const engineTables = {

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -10,8 +10,9 @@ import {
 import { Descriptions } from '../data/characters';
 import * as firstmap from '../data/firstmap';
 import { insertInput } from './game/main';
-import { initAgent, restartAgents, stopAgents } from './agent/init';
+import { initAgent, kickAgents, stopAgents } from './agent/init';
 import { Doc, Id } from './_generated/dataModel';
+import { createEngine, kickEngine, startEngine, stopEngine } from './engine/game';
 
 const init = mutation({
   handler: async (ctx) => {
@@ -26,16 +27,13 @@ const init = mutation({
           '/settings?var=OPENAI_API_KEY',
       );
     }
-    const { world, engine } = await getOrCreateDefaultWorld(ctx.db);
-    if (!engine.active) {
+    const { world, engine } = await getOrCreateDefaultWorld(ctx);
+    if (world.status !== 'running') {
       console.warn(
         `Engine ${engine._id} is not active! Run "npx convex run init:resume" to restart it.`,
       );
       return;
     }
-    // Restart the engine.
-    await restartWorld(ctx, world._id);
-
     // Send inputs to create players for all of the agents.
     if (await shouldCreateAgents(ctx.db, world)) {
       for (const agent of Descriptions) {
@@ -51,44 +49,57 @@ const init = mutation({
         });
       }
     }
-
-    // Restart the agents if needed.
-    await restartAgents(ctx, { worldId: world._id });
   },
 });
 export default init;
 
+export const kick = internalMutation({
+  handler: async (ctx) => {
+    const { world, engine } = await getDefaultWorld(ctx.db);
+    await kickEngine(ctx, internal.game.main.runStep, engine._id);
+    await kickAgents(ctx, { worldId: world._id });
+  },
+});
+
 export const stop = internalMutation({
   handler: async (ctx) => {
     const { world, engine } = await getDefaultWorld(ctx.db);
-    if (!engine.active) {
-      console.warn(`Engine ${engine._id} is already stopped`);
+    if (world.status === 'inactive' || world.status === 'stoppedByDeveloper') {
+      if (engine.state.kind !== 'stopped') {
+        throw new Error(`Engine ${engine._id} isn't stopped?`);
+      }
+      console.debug(`World ${world._id} is already inactive`);
       return;
     }
     console.log(`Stopping engine ${engine._id}...`);
-    await ctx.db.patch(engine._id, { active: false });
-    stopAgents(ctx, { worldId: world._id });
+    await ctx.db.patch(world._id, { status: 'stoppedByDeveloper' });
+    await stopEngine(ctx, engine._id);
+    await stopAgents(ctx, { worldId: world._id });
   },
 });
 
 export const resume = internalMutation({
   handler: async (ctx) => {
     const { world, engine } = await getDefaultWorld(ctx.db);
-    if (engine.active) {
-      console.warn(`Engine ${engine._id} is already active`);
+    if (world.status === 'running') {
+      if (engine.state.kind !== 'running') {
+        throw new Error(`Engine ${engine._id} isn't running?`);
+      }
+      console.debug(`World ${world._id} is already running`);
       return;
     }
-    await ctx.db.patch(engine._id, { active: true });
-    await restartWorld(ctx, world._id);
-    await restartAgents(ctx, { worldId: world._id });
+    console.log(`Resuming engine ${engine._id} for world ${world._id} (state: ${world.status})...`);
+    await ctx.db.patch(world._id, { status: 'running' });
+    await startEngine(ctx, internal.game.main.runStep, engine._id);
+    await kickAgents(ctx, { worldId: world._id });
   },
 });
 
 export const archive = internalMutation({
   handler: async (ctx) => {
     const { world, engine } = await getDefaultWorld(ctx.db);
-    if (engine.active) {
-      throw new Error(`Engine ${engine._id} is still active`);
+    if (engine.state.kind === 'running') {
+      throw new Error(`Engine ${engine._id} is still running!`);
     }
     console.log(`Archiving world ${world._id}...`);
     await ctx.db.patch(world._id, { isDefault: false });
@@ -110,20 +121,15 @@ async function getDefaultWorld(db: DatabaseReader) {
   return { world, engine };
 }
 
-async function getOrCreateDefaultWorld(db: DatabaseWriter) {
+async function getOrCreateDefaultWorld(ctx: MutationCtx) {
   const now = Date.now();
-  let world = await db
+  let world = await ctx.db
     .query('worlds')
     .filter((q) => q.eq(q.field('isDefault'), true))
     .first();
   if (!world) {
-    const engineId = await db.insert('engines', {
-      active: true,
-      currentTime: now,
-      generationNumber: 0,
-      idleUntil: now,
-    });
-    const mapId = await db.insert('maps', {
+    const engineId = await createEngine(ctx, internal.game.main.runStep);
+    const mapId = await ctx.db.insert('maps', {
       width: firstmap.mapWidth,
       height: firstmap.mapHeight,
       tileSetUrl: firstmap.tilesetPath,
@@ -132,15 +138,16 @@ async function getOrCreateDefaultWorld(db: DatabaseWriter) {
       bgTiles: firstmap.bgTiles,
       objectTiles: firstmap.objmap,
     });
-    const worldId = await db.insert('worlds', {
+    const worldId = await ctx.db.insert('worlds', {
       engineId,
       isDefault: true,
       lastViewed: now,
       mapId,
+      status: 'running',
     });
-    world = (await db.get(worldId))!;
+    world = (await ctx.db.get(worldId))!;
   }
-  const engine = await db.get(world.engineId);
+  const engine = await ctx.db.get(world.engineId);
   if (!engine) {
     throw new Error(`Engine ${world.engineId} not found`);
   }
@@ -205,27 +212,3 @@ export const completeAgentCreation = internalMutation({
     await initAgent(ctx, { worldId: args.worldId, playerId, character: args.character });
   },
 });
-
-export async function restartWorld(ctx: MutationCtx, worldId: Id<'worlds'>) {
-  const world = await ctx.db.get(worldId);
-  if (!world) {
-    throw new Error(`Invalid world ID: ${worldId}`);
-  }
-  const engine = await ctx.db.get(world.engineId);
-  if (!engine) {
-    throw new Error(`Invalid engine ID: ${world.engineId}`);
-  }
-  if (!engine.active) {
-    throw new Error(`Engine ${engine._id} isn't active`);
-  }
-  console.log(`Restarting engine ${engine._id}...`);
-  const now = Date.now();
-  const generationNumber = engine.generationNumber + 1;
-  engine.generationNumber = generationNumber;
-  engine.idleUntil = now;
-  await ctx.db.replace(engine._id, engine);
-  await ctx.scheduler.runAt(now, api.game.main.runStep, {
-    worldId: world._id,
-    generationNumber,
-  });
-}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,9 +7,11 @@ export default defineSchema({
   worlds: defineTable({
     isDefault: v.boolean(),
     engineId: v.id('engines'),
-    lastViewed: v.number(),
     mapId: v.id('maps'),
-  }),
+
+    lastViewed: v.number(),
+    status: v.union(v.literal('running'), v.literal('stoppedByDeveloper'), v.literal('inactive')),
+  }).index('engineId', ['engineId']),
   maps: defineTable({
     width: v.number(),
     height: v.number(),


### PR DESCRIPTION
A lot of the engine state transitions ("running" vs. "stopped") and world state transitions ("running" vs. "inactive" vs. "explicitlyStoppedByPlayer") were implicit in the scheduling, which made them bug prone. This PR tightens up the state transitions for the engine rescheduling itself + getting preempted by inputs.

Start and stop are more reliable for me now, but it does easily reproduce the stuttering historical values after a `stop` and then `resume`. I'll work on debugging that next.