### PR TITLE
Bump input preemption window to 1s

### DIFF
--- a/convex/engine/constants.ts
+++ b/convex/engine/constants.ts
@@ -1,2 +1,2 @@
 // Don't preempt the engine unless its scheduled time is at least this far in the future.
-export const ENGINE_WAKEUP_THRESHOLD = 500;
+export const ENGINE_WAKEUP_THRESHOLD = 1000;


### PR DESCRIPTION
I hooked up our logs to axiom (which is awesome!), and one of the first things I noticed is that we're running much more than 1 step a second on average due to input preemption. Previously, we'd preempt the engine if its next run was more than 500ms in the future. Other than running, say, 2 steps per second, this also added another wasted function call since we can't cancel the scheduled engine run in the future we're preempting, which will then subsequently become a noop with a failed generation number check.

This graph shows how the number of runs per 15s window stabilizes to ~15 after the change.

<img width="1912" alt="image" src="https://github.com/get-convex/ai-town/assets/5784949/e1dac7fc-1f64-4aba-a405-4e0a5ec05046">
