### PR TITLE
Bring back non-streaming chatGPT when stream isn't true

### DIFF
--- a/convex/agent/conversation.ts
+++ b/convex/agent/conversation.ts
@@ -53,6 +53,7 @@ export async function startConversation(
       },
     ],
     max_tokens: 300,
+    stream: true,
     stop: stopWords(otherPlayer, player),
   });
   return content;
@@ -103,6 +104,7 @@ export async function continueConversation(
   const { content } = await chatCompletion({
     messages: llmMessages,
     max_tokens: 300,
+    stream: true,
     stop: stopWords(otherPlayer, player),
   });
   return content;
@@ -144,6 +146,7 @@ export async function leaveConversation(
   const { content } = await chatCompletion({
     messages: llmMessages,
     max_tokens: 300,
+    stream: true,
     stop: stopWords(otherPlayer, player),
   });
   return content;

--- a/convex/agent/memory.ts
+++ b/convex/agent/memory.ts
@@ -95,7 +95,7 @@ export async function rememberConversation(
   });
   const description = `Conversation with ${otherPlayer.name} at ${new Date(
     data.conversation._creationTime,
-  ).toLocaleString()}: ${await content.readAll()}`;
+  ).toLocaleString()}: ${content}`;
   const importance = await calculateImportance(player, description);
   const { embedding } = await fetchEmbedding(description);
   authors.delete(player._id);
@@ -238,7 +238,7 @@ export const loadMessages = internalQuery({
 
 async function calculateImportance(player: Doc<'players'>, description: string) {
   // TODO: make a better prompt based on the user's memories
-  const { content } = await chatCompletion({
+  const { content: importanceRaw } = await chatCompletion({
     messages: [
       // {
       //   role: 'user',
@@ -256,7 +256,6 @@ async function calculateImportance(player: Doc<'players'>, description: string) 
     ],
     max_tokens: 1,
   });
-  const importanceRaw = await content.readAll();
 
   let importance = parseFloat(importanceRaw);
   if (isNaN(importance)) {

--- a/convex/util/openai.ts
+++ b/convex/util/openai.ts
@@ -1,5 +1,21 @@
 // That's right! No imports and no dependencies 🤯
 
+// Overload for non-streaming
+export async function chatCompletion(
+  body: Omit<CreateChatCompletionRequest, 'model'> & {
+    model?: CreateChatCompletionRequest['model'];
+  } & {
+    stream?: false | null | undefined;
+  },
+): Promise<{content: string, retries: number, ms: number}> ;
+// Overload for streaming
+export async function chatCompletion(
+  body: Omit<CreateChatCompletionRequest, 'model'> & {
+    model?: CreateChatCompletionRequest['model'];
+  } & {
+    stream?: true;
+  },
+): Promise<{content: ChatCompletionContent, retries: number, ms: number}> ;
 export async function chatCompletion(
   body: Omit<CreateChatCompletionRequest, 'model'> & {
     model?: CreateChatCompletionRequest['model'];
@@ -8,10 +24,9 @@ export async function chatCompletion(
   checkForAPIKey();
 
   body.model = body.model ?? 'gpt-3.5-turbo-16k';
-  body.stream = true;
   const stopWords = body.stop ? (typeof body.stop === 'string' ? [body.stop] : body.stop) : [];
   const {
-    result: resultStream,
+    result: content,
     retries,
     ms,
   } = await retryWithBackoff(async () => {
@@ -32,10 +47,20 @@ export async function chatCompletion(
         ),
       };
     }
-    return result.body!;
+    if (body.stream) {
+      return new ChatCompletionContent(result.body!, stopWords);
+    } else {
+      const json = (await result.json()) as CreateChatCompletionResponse;
+      const content = json.choices[0].message?.content;
+      if (content === undefined) {
+        throw new Error('Unexpected result from OpenAI: ' + JSON.stringify(json));
+      }
+      return content;
+    }
   });
+
   return {
-    content: new ChatCompletionContent(resultStream, stopWords),
+    content,
     retries,
     ms,
   };
@@ -193,6 +218,29 @@ export interface LLMMessage {
      * Validate the arguments in your code before calling your function.
      */
     arguments: string;
+  };
+}
+
+// Non-streaming chat completion response
+interface CreateChatCompletionResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    index?: number;
+    message?: {
+      role: 'system' | 'user' | 'assistant';
+      content: string;
+    };
+    finish_reason?: string;
+  }[];
+  usage?: {
+    completion_tokens: number;
+
+    prompt_tokens: number;
+
+    total_tokens: number;
   };
 }
 


### PR DESCRIPTION
We were ignoring the `stream` parameter and always streaming. For a lot of cases (e.g. prompting for memories) it's not helpful to get a stream back. Provide the non-streaming response in those cases.

Involves a type overload which I hope is acceptable